### PR TITLE
Document validations

### DIFF
--- a/lib/text_delta.ex
+++ b/lib/text_delta.ex
@@ -183,6 +183,8 @@ defmodule TextDelta do
   defdelegate apply!(state, delta), to: Application
   defdelegate lines(delta), to: Document
   defdelegate lines!(delta), to: Document
+  defdelegate invalid_document?(delta), to: Document
+  defdelegate valid_document?(delta), to: Document
   defdelegate diff(first, second), to: Difference
   defdelegate diff!(first, second), to: Difference
 

--- a/lib/text_delta.ex
+++ b/lib/text_delta.ex
@@ -183,8 +183,8 @@ defmodule TextDelta do
   defdelegate apply!(state, delta), to: Application
   defdelegate lines(delta), to: Document
   defdelegate lines!(delta), to: Document
-  defdelegate invalid_document?(delta), to: Document
-  defdelegate valid_document?(delta), to: Document
+  defdelegate is_invalid_document?(delta), to: Document
+  defdelegate is_valid_document?(delta), to: Document
   defdelegate diff(first, second), to: Difference
   defdelegate diff!(first, second), to: Difference
 

--- a/lib/text_delta/attributes.ex
+++ b/lib/text_delta/attributes.ex
@@ -241,20 +241,20 @@ defmodule TextDelta.Attributes do
     |> Enum.into(%{})
   end
 
-  def invalid_document_attributes?(attrs) when is_nil(attrs), do: true
+  def are_invalid_document_attributes?(attrs) when is_nil(attrs), do: true
 
-  def invalid_document_attributes?(attrs) do
+  def are_invalid_document_attributes?(attrs) do
     attrs
-      |> Enum.find(&invalid_document_attribute?/1)
+      |> Enum.find(fn {_, attr} -> is_invalid_document_attribute?(attr) end)
       |> case do
         nil -> false
         _ -> true
       end
   end
 
-  def invalid_document_attribute?({_, %{ops: _} = attr}) do
-    Document.invalid_document?(attr)
+  def is_invalid_document_attribute?(%{ops: _} = attr) do
+    Document.is_invalid_document?(attr)
   end
 
-  def invalid_document_attribute?(_), do: false
+  def is_invalid_document_attribute?(_), do: false
 end

--- a/lib/text_delta/attributes.ex
+++ b/lib/text_delta/attributes.ex
@@ -8,6 +8,8 @@ defmodule TextDelta.Attributes do
   does not make any assumptions about attribute types, values or composition.
   """
 
+  alias TextDelta.Document
+
   @typedoc """
   A set of attributes applicable to an operation.
   """
@@ -238,4 +240,21 @@ defmodule TextDelta.Attributes do
     |> Enum.filter(fn {key, _} -> not Map.has_key?(attrs_b, key) end)
     |> Enum.into(%{})
   end
+
+  def invalid_document_attributes?(attrs) when is_nil(attrs), do: true
+
+  def invalid_document_attributes?(attrs) do
+    attrs
+      |> Enum.find(&invalid_document_attribute?/1)
+      |> case do
+        nil -> false
+        _ -> true
+      end
+  end
+
+  def invalid_document_attribute?({_, %{ops: _} = attr}) do
+    Document.invalid_document?(attr)
+  end
+
+  def invalid_document_attribute?(_), do: false
 end

--- a/lib/text_delta/document.ex
+++ b/lib/text_delta/document.ex
@@ -53,7 +53,7 @@ defmodule TextDelta.Document do
   """
   @spec lines(TextDelta.state()) :: lines_result
   def lines(doc) do
-    case valid_document?(doc) do
+    case is_valid_document?(doc) do
       true -> {:ok, op_lines(TextDelta.operations(doc), TextDelta.new())}
       false -> {:error, :bad_document}
     end
@@ -110,18 +110,18 @@ defmodule TextDelta.Document do
     end
   end
 
-  def valid_document?(document) do
-    not invalid_document?(document)
+  def is_valid_document?(document) do
+    not is_invalid_document?(document)
   end
 
-  def invalid_document?(%{ops: ops}) do
+  def is_invalid_document?(%{ops: ops}) do
     ops
-      |> Enum.find(&Operation.invalid_document_operation?/1)
+      |> Enum.find(&Operation.is_invalid_document_operation?/1)
       |> case do
         nil -> false
         _ -> true
       end
   end
 
-  def invalid_document?(_), do: true
+  def is_invalid_document?(_), do: true
 end

--- a/lib/text_delta/document.ex
+++ b/lib/text_delta/document.ex
@@ -110,7 +110,18 @@ defmodule TextDelta.Document do
     end
   end
 
-  defp valid_document?(document) do
-    TextDelta.length(document) == TextDelta.length(document, [:insert])
+  def valid_document?(document) do
+    not invalid_document?(document)
   end
+
+  def invalid_document?(%{ops: ops}) do
+    ops
+      |> Enum.find(&Operation.invalid_document_operation?/1)
+      |> case do
+        nil -> false
+        _ -> true
+      end
+  end
+
+  def invalid_document?(_), do: true
 end

--- a/lib/text_delta/operation.ex
+++ b/lib/text_delta/operation.ex
@@ -332,10 +332,10 @@ defmodule TextDelta.Operation do
     Map.has_key?(op, :retain) and !Map.has_key?(op, :attributes)
   end
 
-  def invalid_document_operation?(%{insert: _, attributes: attrs}) do
-    Attributes.invalid_document_attributes?(attrs)
+  def is_invalid_document_operation?(%{insert: _, attributes: attrs}) do
+    Attributes.are_invalid_document_attributes?(attrs)
   end
 
-  def invalid_document_operation?(%{insert: _}), do: false
-  def invalid_document_operation?(_), do: true
+  def is_invalid_document_operation?(%{insert: _}), do: false
+  def is_invalid_document_operation?(_), do: true
 end

--- a/lib/text_delta/operation.ex
+++ b/lib/text_delta/operation.ex
@@ -331,4 +331,11 @@ defmodule TextDelta.Operation do
   def trimmable?(op) do
     Map.has_key?(op, :retain) and !Map.has_key?(op, :attributes)
   end
+
+  def invalid_document_operation?(%{insert: _, attributes: attrs}) do
+    Attributes.invalid_document_attributes?(attrs)
+  end
+
+  def invalid_document_operation?(%{insert: _}), do: false
+  def invalid_document_operation?(_), do: true
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,1 @@
 ExUnit.start()
-
-"./test/support"
-|> File.ls!()
-|> Enum.each(&Code.require_file("support/#{&1}", __DIR__))

--- a/test/text_delta/document_test.exs
+++ b/test/text_delta/document_test.exs
@@ -202,7 +202,7 @@ defmodule TextDelta.DocumentTest do
       assert TextDelta.is_invalid_document?(b_delta) == false
     end
 
-    test "invalid delta #1" do
+    test "invalid delta containing retain operation" do
       delta =
         TextDelta.new()
         |> TextDelta.insert("a")
@@ -212,7 +212,7 @@ defmodule TextDelta.DocumentTest do
       assert TextDelta.is_invalid_document?(delta) == true
     end
 
-    test "invalid delta #2" do
+    test "invalid delta containing delete operation" do
       delta =
         TextDelta.new()
         |> TextDelta.insert("a")
@@ -222,7 +222,7 @@ defmodule TextDelta.DocumentTest do
       assert TextDelta.is_invalid_document?(delta) == true
     end
 
-    test "invalid nested delta #1" do
+    test "invalid delta containing nested retain operation" do
       a_delta =
         TextDelta.new()
         |> TextDelta.insert("a")
@@ -237,7 +237,7 @@ defmodule TextDelta.DocumentTest do
       assert TextDelta.is_invalid_document?(b_delta) == true
     end
 
-    test "invalid nested delta #2" do
+    test "invalid delta containing nested delete operation" do
       a_delta =
         TextDelta.new()
         |> TextDelta.insert("a")

--- a/test/text_delta/document_test.exs
+++ b/test/text_delta/document_test.exs
@@ -176,6 +176,62 @@ defmodule TextDelta.DocumentTest do
     end
   end
 
+  test "document validation" do
+    # Valid delta
+    delta =
+      TextDelta.new()
+      |> TextDelta.insert("a")
+      |> TextDelta.insert("b", %{bold: true})
+
+    assert TextDelta.valid_document?(delta) == true
+    assert TextDelta.invalid_document?(delta) == false
+
+    # Valid nested delta
+    a_delta =
+      TextDelta.new()
+      |> TextDelta.insert("a")
+      |> TextDelta.insert("b", %{bold: true, content: delta})
+
+    assert TextDelta.valid_document?(a_delta) == true
+    assert TextDelta.invalid_document?(a_delta) == false
+
+    # Invalid delta
+    b_delta =
+      TextDelta.new()
+      |> TextDelta.insert("a")
+      |> TextDelta.retain(1)
+
+    assert TextDelta.valid_document?(b_delta) == false
+    assert TextDelta.invalid_document?(b_delta) == true
+
+    # Invalid delta
+    c_delta =
+      TextDelta.new()
+      |> TextDelta.insert("a")
+      |> TextDelta.delete(1)
+
+    assert TextDelta.valid_document?(c_delta) == false
+    assert TextDelta.invalid_document?(c_delta) == true
+
+    # Valid delta containing invalid nested delta
+    d_delta =
+      TextDelta.new()
+      |> TextDelta.insert("a")
+      |> TextDelta.insert("b", %{bold: true, content: b_delta})
+
+    assert TextDelta.valid_document?(d_delta) == false
+    assert TextDelta.invalid_document?(d_delta) == true
+
+    # Valid delta containing invalid nested delta
+    e_delta =
+      TextDelta.new()
+      |> TextDelta.insert("a")
+      |> TextDelta.insert("b", %{bold: true, content: c_delta})
+
+    assert TextDelta.valid_document?(e_delta) == false
+    assert TextDelta.invalid_document?(e_delta) == true
+  end
+
   describe "lines!" do
     test "proper document" do
       delta =

--- a/test/text_delta/document_test.exs
+++ b/test/text_delta/document_test.exs
@@ -176,60 +176,81 @@ defmodule TextDelta.DocumentTest do
     end
   end
 
-  test "document validation" do
-    # Valid delta
-    delta =
-      TextDelta.new()
-      |> TextDelta.insert("a")
-      |> TextDelta.insert("b", %{bold: true})
+  describe "document validation" do
+    test "valid delta" do
+      delta =
+        TextDelta.new()
+        |> TextDelta.insert("a")
+        |> TextDelta.insert("b", %{bold: true})
 
-    assert TextDelta.is_valid_document?(delta) == true
-    assert TextDelta.is_invalid_document?(delta) == false
+      assert TextDelta.is_valid_document?(delta) == true
+      assert TextDelta.is_invalid_document?(delta) == false
+    end
 
-    # Valid nested delta
-    a_delta =
-      TextDelta.new()
-      |> TextDelta.insert("a")
-      |> TextDelta.insert("b", %{bold: true, content: delta})
+    test "valid nested delta" do
+      a_delta =
+        TextDelta.new()
+        |> TextDelta.insert("a")
+        |> TextDelta.insert("b", %{bold: true})
 
-    assert TextDelta.is_valid_document?(a_delta) == true
-    assert TextDelta.is_invalid_document?(a_delta) == false
+      b_delta =
+        TextDelta.new()
+        |> TextDelta.insert("a")
+        |> TextDelta.insert("b", %{bold: true, content: a_delta})
 
-    # Invalid delta
-    b_delta =
-      TextDelta.new()
-      |> TextDelta.insert("a")
-      |> TextDelta.retain(1)
+      assert TextDelta.is_valid_document?(b_delta) == true
+      assert TextDelta.is_invalid_document?(b_delta) == false
+    end
 
-    assert TextDelta.is_valid_document?(b_delta) == false
-    assert TextDelta.is_invalid_document?(b_delta) == true
+    test "invalid delta #1" do
+      delta =
+        TextDelta.new()
+        |> TextDelta.insert("a")
+        |> TextDelta.retain(1)
 
-    # Invalid delta
-    c_delta =
-      TextDelta.new()
-      |> TextDelta.insert("a")
-      |> TextDelta.delete(1)
+      assert TextDelta.is_valid_document?(delta) == false
+      assert TextDelta.is_invalid_document?(delta) == true
+    end
 
-    assert TextDelta.is_valid_document?(c_delta) == false
-    assert TextDelta.is_invalid_document?(c_delta) == true
+    test "invalid delta #2" do
+      delta =
+        TextDelta.new()
+        |> TextDelta.insert("a")
+        |> TextDelta.delete(1)
 
-    # Valid delta containing invalid nested delta
-    d_delta =
-      TextDelta.new()
-      |> TextDelta.insert("a")
-      |> TextDelta.insert("b", %{bold: true, content: b_delta})
+      assert TextDelta.is_valid_document?(delta) == false
+      assert TextDelta.is_invalid_document?(delta) == true
+    end
 
-    assert TextDelta.is_valid_document?(d_delta) == false
-    assert TextDelta.is_invalid_document?(d_delta) == true
+    test "invalid nested delta #1" do
+      a_delta =
+        TextDelta.new()
+        |> TextDelta.insert("a")
+        |> TextDelta.retain(1)
 
-    # Valid delta containing invalid nested delta
-    e_delta =
-      TextDelta.new()
-      |> TextDelta.insert("a")
-      |> TextDelta.insert("b", %{bold: true, content: c_delta})
+      b_delta =
+        TextDelta.new()
+        |> TextDelta.insert("a")
+        |> TextDelta.insert("b", %{bold: true, content: a_delta})
 
-    assert TextDelta.is_valid_document?(e_delta) == false
-    assert TextDelta.is_invalid_document?(e_delta) == true
+      assert TextDelta.is_valid_document?(b_delta) == false
+      assert TextDelta.is_invalid_document?(b_delta) == true
+    end
+
+    test "invalid nested delta #2" do
+      a_delta =
+        TextDelta.new()
+        |> TextDelta.insert("a")
+        |> TextDelta.delete(1)
+
+      b_delta =
+        TextDelta.new()
+        |> TextDelta.insert("a")
+        |> TextDelta.insert("b", %{bold: true, content: a_delta})
+
+      assert TextDelta.is_valid_document?(b_delta) == false
+      assert TextDelta.is_invalid_document?(b_delta) == true
+    end
   end
 
   describe "lines!" do

--- a/test/text_delta/document_test.exs
+++ b/test/text_delta/document_test.exs
@@ -183,8 +183,8 @@ defmodule TextDelta.DocumentTest do
       |> TextDelta.insert("a")
       |> TextDelta.insert("b", %{bold: true})
 
-    assert TextDelta.valid_document?(delta) == true
-    assert TextDelta.invalid_document?(delta) == false
+    assert TextDelta.is_valid_document?(delta) == true
+    assert TextDelta.is_invalid_document?(delta) == false
 
     # Valid nested delta
     a_delta =
@@ -192,8 +192,8 @@ defmodule TextDelta.DocumentTest do
       |> TextDelta.insert("a")
       |> TextDelta.insert("b", %{bold: true, content: delta})
 
-    assert TextDelta.valid_document?(a_delta) == true
-    assert TextDelta.invalid_document?(a_delta) == false
+    assert TextDelta.is_valid_document?(a_delta) == true
+    assert TextDelta.is_invalid_document?(a_delta) == false
 
     # Invalid delta
     b_delta =
@@ -201,8 +201,8 @@ defmodule TextDelta.DocumentTest do
       |> TextDelta.insert("a")
       |> TextDelta.retain(1)
 
-    assert TextDelta.valid_document?(b_delta) == false
-    assert TextDelta.invalid_document?(b_delta) == true
+    assert TextDelta.is_valid_document?(b_delta) == false
+    assert TextDelta.is_invalid_document?(b_delta) == true
 
     # Invalid delta
     c_delta =
@@ -210,8 +210,8 @@ defmodule TextDelta.DocumentTest do
       |> TextDelta.insert("a")
       |> TextDelta.delete(1)
 
-    assert TextDelta.valid_document?(c_delta) == false
-    assert TextDelta.invalid_document?(c_delta) == true
+    assert TextDelta.is_valid_document?(c_delta) == false
+    assert TextDelta.is_invalid_document?(c_delta) == true
 
     # Valid delta containing invalid nested delta
     d_delta =
@@ -219,8 +219,8 @@ defmodule TextDelta.DocumentTest do
       |> TextDelta.insert("a")
       |> TextDelta.insert("b", %{bold: true, content: b_delta})
 
-    assert TextDelta.valid_document?(d_delta) == false
-    assert TextDelta.invalid_document?(d_delta) == true
+    assert TextDelta.is_valid_document?(d_delta) == false
+    assert TextDelta.is_invalid_document?(d_delta) == true
 
     # Valid delta containing invalid nested delta
     e_delta =
@@ -228,8 +228,8 @@ defmodule TextDelta.DocumentTest do
       |> TextDelta.insert("a")
       |> TextDelta.insert("b", %{bold: true, content: c_delta})
 
-    assert TextDelta.valid_document?(e_delta) == false
-    assert TextDelta.invalid_document?(e_delta) == true
+    assert TextDelta.is_valid_document?(e_delta) == false
+    assert TextDelta.is_invalid_document?(e_delta) == true
   end
 
   describe "lines!" do


### PR DESCRIPTION
Implements `TextDelta.valid_document(TextDelta)` and `TextDelta.invalid_document(TextDelta)`

A valid document delta is a delta that only contains `insert` operations, including nested deltas

There was a private `defp valid_document?(document)` already in place, but it only checked the root operations, the tests are still passing and that method is used only for `TextDelta.lines`, which we are not interested in

would suggest to merge `21-02-test-polishing` into master after this as well