### PR TITLE
mix: tag in preparation for elixir 1.13.0 compatibility

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule TextDelta.Mixfile do
   use Mix.Project
 
-  @version "1.7.1"
+  @version "1.7.2"
   @github_url "https://github.com/MeisterLabs/text_delta"
 
   def project do


### PR DESCRIPTION
As part of cleaning up `mix.exs` in mn-api repo, use a tag
and roll a new version here instead of a random commit ref.